### PR TITLE
Change size of item based on font size

### DIFF
--- a/Gspot.lua
+++ b/Gspot.lua
@@ -465,6 +465,8 @@ Gspot.util = {
 		end
 		if pcall(function(font) return font:type() == 'Font' end, font) then
 			this.style.font = font
+			this.pos.w = this.style.font:getWidth(this.label)
+			this.pos.h = this.style.font:getHeight()
 		else
 			this.style.font = nil
 			this.style = this.Gspot:clone(this.style)

--- a/Gspot.lua
+++ b/Gspot.lua
@@ -465,8 +465,10 @@ Gspot.util = {
 		end
 		if pcall(function(font) return font:type() == 'Font' end, font) then
 			this.style.font = font
-			this.pos.w = this.style.font:getWidth(this.label)
-			this.pos.h = this.style.font:getHeight()
+			if this.autosize then
+				this.pos.w = this.style.font:getWidth(this.label)
+				this.pos.h = this.style.font:getHeight()
+			end
 		else
 			this.style.font = nil
 			this.style = this.Gspot:clone(this.style)
@@ -740,7 +742,8 @@ Gspot.image = {
 setmetatable(Gspot.image, {__index = Gspot.util, __call = Gspot.image.load})
 
 Gspot.button = {
-	load = function(this, Gspot, label, pos, parent)
+	load = function(this, Gspot, label, pos, parent, autosize)
+		if autosize then this.autosize = autosize end
 		return Gspot:add(Gspot:element('button', label, pos, parent))
 	end,
 	draw = function(this, pos)


### PR DESCRIPTION
When `thing:setfont()` is called, the width/height of `thing` is not updated. This leads to the following:

* Before

 ![Screenie](https://cloud.githubusercontent.com/assets/4751549/19877066/306fc128-9fb2-11e6-9d46-a10ce5db8438.png)

Changing the size of the item based on the font size of it's label:

* After

 ![Fixed screenie](https://cloud.githubusercontent.com/assets/4751549/19877133/df1d7346-9fb2-11e6-8c21-190b91a8ffe4.png)

There's probably some adjustment to be made around the padding of the item, but I think it's a good start.

Also I've been farting around with a bunch of the other UI libraries on [awesome-love2d](https://github.com/love2d-community/awesome-love2d#ui) and I think this is the best one out of them all. :+1: